### PR TITLE
Simplify CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,11 @@ layout: layout.html
 
 <h1>UrbanBlogs</h1>
 
-<h2><a href="/posts/first">First Post: DC Review</a></h2>
+<h2 class="no_bottom_margin"><a href="/posts/first">First Post: DC Review</a></h2>
 
-<span class="no_br"><h4><time datetime="2023-08-02"> August 2, 2023</time></h4></span>
+<span class="no_margin"><h4><time datetime="2023-08-02"> August 2, 2023</time></h4></span>
 
-<h3 class="no_br">America's capital city rated based on the core principles of urban design: transit, development, and street design. </h3>
+<h3 class="no_margin">America's capital city rated based on the core principles of urban design: transit, development, and street design. </h3>
 
 <p style= "text-align: center;">Welcome! I'm David, an NYC college student with an interest in urban planning and programming! Join me as I review the cities I visit, make cool coding projects, and post videos about transit and urbanism! You can also find me on <a href="https://www.youtube.com/channel/UCFHGqAg1OPhtGqTFLS2EtiA" target="_blank" rel="noopener noreferrer">YouTube</a>, <a href="https://www.linkedin.com/in/david-oke-73a093107/" target="_blank" rel="noopener noreferrer">LinkedIn</a>, <a href="https://github.com/doke05c" target="_blank" rel="noopener noreferrer">GitHub</a>, and <a href="https://www.instagram.com/addiv2005/" target="_blank" rel="noopener noreferrer">Instagram</a> :)</p>
 

--- a/styles.css
+++ b/styles.css
@@ -54,11 +54,13 @@ a {
     color: #7DA9DE;
 }
 
-/* When I want no linebreak space */
-.no_br {
+/* When I want no margin */
+.no_margin {
     margin-block : 0;
-    margin-top : -30px;
-    display: block;
+}
+
+.no_bottom_margin{
+    margin-bottom: 0;
 }
 
 /* When I want stuff at the bottom of the page */

--- a/styles.css
+++ b/styles.css
@@ -45,7 +45,7 @@ p {
     font-size: 19px;
 }
 
-h1, h2, h3, h4, h5, h6, p, li {
+main > * {
     margin-block: 35px;
 }
 


### PR DESCRIPTION
Target all immediate children without repetition 
All the headings and Ps and LIs will still have the specified margin, but if you ever decide to use different elements, those will also be targeted and have margin automatically as well, without the need to explicitly target them here.

Simplify margin styles to be more consistent across all possible screensizes and scaling
